### PR TITLE
Fix IReporter import error: Update dependencies and supported python to latest versions

### DIFF
--- a/pylint_json2checkstyle/checkstyle_reporter.py
+++ b/pylint_json2checkstyle/checkstyle_reporter.py
@@ -8,7 +8,6 @@ from itertools import groupby
 from typing import Optional, List
 from xml.dom import minidom
 
-from pylint.interfaces import IReporter
 from pylint.lint.pylinter import PyLinter
 from pylint.message import Message
 from pylint.reporters.base_reporter import BaseReporter
@@ -84,7 +83,6 @@ class CheckstyleReporter(BaseReporter):
     """
     Outputs pylint errors in checkstyle format
     """
-    __implements__ = IReporter
     name = "checkstyle"
     extension = "xml"
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-build==0.7.0
-pylint==2.13.9
-pytest==7.0.1
-twine==3.8.0
-typing_extensions==4.1.1
+build==1.0.3
+pylint==3.0.3
+pytest==7.4.4
+twine==4.0.2
+typing_extensions==4.9.0
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -9,6 +9,7 @@ long_description_content_type = text/markdown
 url = https://github.com/caarmen/pylint-json2checkstyle
 project_urls =
     Bug Tracker = https://github.com/caarmen/pylint-json2checkstyle/issues
+    Releases = https://github.com/caarmen/pylint-json2checkstyle/releases
 classifiers =
     Development Status :: 3 - Alpha
     Environment :: Console

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = pylint_json2checkstyle
-version = 0.0.11
+version = 0.0.12
 author = Carmen Alvarez
 author_email = carmen@rmen.ca
 description = A Pylint plugin and command line tool to produce Pylint reports in checkstyle format.
@@ -23,6 +23,7 @@ classifiers =
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
+    Programming Language :: Python :: 3.12
 [options]
 packages = pylint_json2checkstyle
 python_requires = >=3.6


### PR DESCRIPTION
Remove the `__implements__ = IReporter` to avoid issue #5.
    
This was removed in pylint in https://github.com/pylint-dev/pylint/pull/8404